### PR TITLE
Track link clicks

### DIFF
--- a/content/templates/base.js
+++ b/content/templates/base.js
@@ -1,3 +1,14 @@
 window.ga = function () { ga.q.push(arguments) }
 ga.l = +new Date
 ga.q = [['create', 'UA-99854195-1', 'auto'], ['send', 'pageview']]
+
+document.addEventListener('click', function (e) {
+  if (e.target.tagName.toLowerCase() === 'a') {
+    e.preventDefault()
+    url = e.target.href
+    ga('send', 'event', 'link', 'click', url, {
+      transport: 'beacon',
+      hitCallback: function () { document.location = url }
+    })
+  }
+})


### PR DESCRIPTION
This fixes #68. I'm not sure that I want to do this, since following any link requires a round-trip to Google. 