### PR TITLE
Avoid misleading naming

### DIFF
--- a/content/issues/59.markdown
+++ b/content/issues/59.markdown
@@ -47,7 +47,7 @@ This is a weekly summary of what's going on in its community.
 
 -   [Use hpack](https://e.xtendo.org/haskell/hpack)
 
-    > One of the remaining problems is that the `project.cabal` file is in a custom format. Custom formats are generally not good because you can't leverage the existing tools and free-ride other people's work.
+    > One of the remaining problems is that the `package.cabal` file is in a custom format. Custom formats are generally not good because you can't leverage the existing tools and free-ride other people's work.
 
 -   [Haskell taketh away: Limiting side effects for parallel programming](https://www.youtube.com/watch?v=lC5UWG5N8oY)
 


### PR DESCRIPTION
It's misleading to refer to a `.cabal` being a project rather than a package, since there's also the `cabal.project` file to denote an actual project comprised of one or more packages as well as project-specific settings. `.cabal` files are specifications of the unit of distributions (i.e. a "package" is our unit of distribution), they don't describe projects.