### PR TITLE
Adds Servant issue 752 to CFP

### DIFF
--- a/content/issues/63.markdown
+++ b/content/issues/63.markdown
@@ -24,6 +24,7 @@ Here are some tasks from the Haskell community for you to pick and get started!
 - [cabal: Print out more information about the effective configuration when you build](https://github.com/haskell/cabal/issues/3945)
 - [esqueleto: Make examples for the README buildable](https://github.com/bitemyapp/esqueleto/issues/4)
 - [miso: phantomjs2 fails to build on OSX](https://github.com/dmjio/miso/issues/160)
+- [servant: BasicAuthentication has no documentation for client-side use](https://github.com/haskell-servant/servant/issues/752)
 - [stack: `stack new` can't be pointed at an intranet site](https://github.com/commercialhaskell/stack/issues/2804)
 - [text: Add tshow function](https://github.com/bos/text/issues/183)
 


### PR DESCRIPTION
This should be a relatively straightforward issue for adding documentation and examples of client-side Basic Authentication in Servant. The maintainers seem to have indicated that some mentorship or general help could be provided to those who need it.