### PR TITLE
Switch from String to Text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /*.cabal
 /*.hp
 /*.prof
+/*.tix


### PR DESCRIPTION
This switches as many things as possible from `String` to `Text`. Some strings stuck around because file paths and time parsing/formatting require them. But rending CommonMark is by far the bulk of the work here and it requires text. 