### PR TITLE
Add a page describing advertising

### DIFF
--- a/content/templates/advertising.html
+++ b/content/templates/advertising.html
@@ -1,0 +1,62 @@
+<h2>Advertising</h2>
+
+<p>
+  You can advertise with Haskell Weekly by purchasing a sponsored link.
+  Sponsored links are similar to featured links except that they say "(ad)" after the title.
+  Here's an example of how they look:
+</p>
+
+<ul>
+  <li>
+    <p>
+      <a href>Reach an engaged audience by advertising with Haskell Weekly!</a>
+      (ad)
+    </p>
+    <blockquote>
+      <p>
+        Over 1,500 people subscribe to Haskell Weekly.
+        We deliver a new issue to their inbox every week.
+        Over the last five issues,
+        77% of subscribers opened at least one issue
+        and 52% clicked on at least one link.
+      </p>
+    </blockquote>
+  </li>
+</ul>
+
+<p>
+  Each sponsored link has three required pieces:
+</p>
+
+<ol>
+  <li>
+    <p>
+      URL:
+      This can be whatever you want.
+      We recommend using a URL that will allow you to track engagement.
+      For example, <a href="https://goo.gl">Google's link shortener</a> provides analytics data.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      Title:
+      This is up to 80 characters of plain text.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      Copy:
+      This is up to 300 characters of plain text.
+      It can include basic Markdown formatting.
+    </p>
+  </li>
+</ol>
+
+<p>
+  Sponsored links cost US$$60 per issue.
+  Payment is accepted through <a href="https://squareup.com">Square</a>.
+  If you are interesting in advertising with Haskell Weekly,
+  please reach out to <a href="mailto:info@haskellweekly.news?subject=Advertising">info@haskellweekly.news</a>.
+</p>

--- a/executables/haskell-weekly.hs
+++ b/executables/haskell-weekly.hs
@@ -51,7 +51,8 @@ main = do
   let
     context :: Context
     context =
-      [ ("baseUrl", "https://haskellweekly.news")
+      [ ("", "$")
+      , ("baseUrl", "https://haskellweekly.news")
       , ("form", form)
       , ("logo", logo)
       , ("script", script)
@@ -59,6 +60,7 @@ main = do
       ]
 
   -- Read templates.
+  advertisingTemplate <- readFileAt [input, "templates", "advertising.html"]
   atomEntryTemplate <- readFileAt [input, "templates", "atom-entry.xml"]
   atomTemplate <- readFileAt [input, "templates", "atom.xml"]
   baseTemplate <- readFileAt [input, "templates", "base.html"]
@@ -96,6 +98,11 @@ main = do
   do
     contents <- renderRss rssTemplate rssItemTemplate context recentIssues
     writeFileAt [output, "haskell-weekly.rss"] contents
+
+  -- Create advertising page.
+  do
+    contents <- renderAdvertising baseTemplate advertisingTemplate context
+    writeFileAt [output, "advertising.html"] contents
 
   -- Create home page.
   do
@@ -192,6 +199,16 @@ summary =
   \content about Haskell from around the web."
 
 -- Rendering helpers
+
+renderAdvertising :: Monad m => Text -> Text -> Context -> m Text
+renderAdvertising template advertisingTemplate context = do
+  body <- renderTemplate advertisingTemplate context
+  renderTemplate template (context <>
+    [ ("body", body)
+    , ("summary", "Information about advertising with Haskell Weekly.")
+    , ("title", pageTitle (Just "Advertising"))
+    , ("url", "/advertising.html")
+    ])
 
 renderAtom :: Monad m => Text -> Text -> Context -> [Issue] -> m Text
 renderAtom template entryTemplate context issues = do


### PR DESCRIPTION
This fixes #89. 

I haven't linked to this page from anywhere on the site yet, but just having it should make things better. 