### PR TITLE
Add massiv as a package of the week to issue-95

### DIFF
--- a/content/issues/95.markdown
+++ b/content/issues/95.markdown
@@ -16,7 +16,8 @@ undefined
 
 ## Package of the week
 
-undefined
+This week's package of the week is [massiv](https://hackage.haskell.org/package/massiv),
+a library for multi-dimensional Arrays with fusion, stencils and parallel computation.
 
 ## Call for participation
 


### PR DESCRIPTION
I'd like to recommend newly released package [massiv](https://hackage.haskell.org/package/massiv) for the package of the week. More info on the package is on it's github page [github.com/lehins/massiv](https://github.com/lehins/massiv)