### PR TITLE
Updated Auckland meetup title

### DIFF
--- a/content/issues/109.markdown
+++ b/content/issues/109.markdown
@@ -29,4 +29,4 @@ undefined
 
 ## Events
 
--   June 6: [Auckland FP Meetup: 3 Talks: Serverless Haskell; Prototyping for Radar; Pure TensorFlow Combinators](https://www.meetup.com/Functional-Programming-Auckland/events/250854233/) in Auckland, New Zealand
+-   June 6: [Auckland FP Meetup: 3 Talks: Remote Haskell; Prototyping for Radar; Pure TensorFlow Combinators](https://www.meetup.com/Functional-Programming-Auckland/events/250854233/) in Auckland, New Zealand


### PR DESCRIPTION
Author of new library decided to not have "serverless" in the library name, hence changed talk title.