### PR TITLE
Issue 123 - Add VanFP "Haskell Book Workshop" event

### DIFF
--- a/content/issues/123.markdown
+++ b/content/issues/123.markdown
@@ -26,4 +26,4 @@ undefined
 
 ## Events
 
-undefined
+- 2018-09-19 in Vancouver, Canada by VanFP: [Vancouver's Haskell Book Workshop](https://www.meetup.com/Vancouver-Functional-Programmers/events/pzvcfqyxmbqb/)


### PR DESCRIPTION

Add event to Issue 123 of Haskell Weekly