### PR TITLE
Use year-month-day date format

### DIFF
--- a/executables/haskell-weekly.hs
+++ b/executables/haskell-weekly.hs
@@ -223,7 +223,7 @@ parseIssue (number, contents) = do
     }
 
 prettyDay :: Time.Day -> Text
-prettyDay = formatDay "%B %e %Y"
+prettyDay = formatDay "%Y-%m-%d"
 
 rfcDay :: Time.Day -> Text
 rfcDay = formatDay "%a, %d %b %Y 00:00:00 GMT"


### PR DESCRIPTION
Haskellweekly is an international newsletter and therefore I think it should use the international date format. It's also easier and more efficient to read, as one has only read as many segments as they are interested in. If they only want to know the year, they don't have to read the useless noise "December 12" first. (I mean that's the reason why it's the international date format in the first place ... it just makes the most sense =P)
You're also already using it for the events...